### PR TITLE
Less agressive failures

### DIFF
--- a/src/command.coffee
+++ b/src/command.coffee
@@ -17,6 +17,7 @@ module.exports.run = ->
           console.log "#{numeral(item.quantity).format("0,0.00000000")} #{item.asset}"
         else
           console.error _.merge(item, raw: "[object]")
+      process.exit 0
     .catch (error) ->
       console.error error
       process.exit 1

--- a/src/crypto-balance.coffee
+++ b/src/crypto-balance.coffee
@@ -6,11 +6,14 @@ normalizeAssetName = require('./asset-names').normalize
 balance = (addr, callback) ->
 
   Promise
-    .all(fn(addr) for s, fn of services)
+    .settle(fn(addr) for s, fn of services)
     .timeout(20000)
     .cancellable()
+    .map (pi) -> pi.isFulfilled() and pi.value()
     .filter (item) -> !!item
-    .reduce (a, b) -> a.concat b
+    .reduce (a, b) ->
+      a.concat b
+    , []
     .filter (asset) ->
       !asset.address or asset.address == addr
     .map (item) ->


### PR DESCRIPTION
This is a quick fix for the broken site. I used `settle` instead of `all` and filter for fulfilled promisses. This way we separate failures from successes and prevent from empty result when some services fail.