### PR TITLE
json.address is not always there

### DIFF
--- a/src/services/mastercoin.coffee
+++ b/src/services/mastercoin.coffee
@@ -12,7 +12,7 @@ msc = (addr) ->
     .timeout(10000)
     .cancellable()
     .spread (resp, json) ->
-      if resp.statusCode in [200..299] and json.address == addr and _.isArray(json.balance)
+      if resp.statusCode in [200..299] and _.isArray(json.balance)
         json.balance
       else
         throw new InvalidResponseError service: url, response: resp


### PR DESCRIPTION
I tested a couple of addresses and `address` property wasn't set for any of them (causing `InvalidResponseErrors`). [The API](https://github.com/mastercoin-MSC/omniwallet#find-out-the-balance-information-for-a-given-address) does not say is if the presented in their example properties are always there or not.
